### PR TITLE
Fix unquoted boolean values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,13 +39,13 @@ services:
       KC_DB_DATABASE: keycloak
       KC_DB_USERNAME: keycloaker
       KC_DB_PASSWORD: keycloaked
-      KC_HTTP_ENABLED: false
-      KC_HTTPS_ENABLED: false
+      KC_HTTP_ENABLED: "False"
+      KC_HTTPS_ENABLED: "False"
       KC_PROXY: edge
       KC_HOSTNAME: localhost
       KC_HOSTNAME_PORT: 8080
-      KC_HOSTNAME_STRICT: false
-      KC_HOSTNAME_STRICT_HTTPS: false
+      KC_HOSTNAME_STRICT: "False"
+      KC_HOSTNAME_STRICT_HTTPS: "False"
       KC_LOG_LEVEL: INFO
       VAR_ADMIN_CLI_SECRET: "xxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyy"
       VAR_WEB_CLIENT_URL: "http://localhost:5500"


### PR DESCRIPTION
Boolean values need to be quoted or they won't be parsed as strings by the interpreter. It will throw these errors:

`ERROR: The Compose file './docker-compose.yml' is invalid because: services.keycloak.environment.KC_HTTP_ENABLED contains false, which is an invalid type, it should be a string, number, or a null`


`ERROR: The Compose file './docker-compose.yml' is invalid because: services.keycloak.environment.KC_HTTPS_ENABLED contains true, which is an invalid type, it should be a string, number, or a null`


`ERROR: The Compose file './docker-compose.yml' is invalid because: services.keycloak.environment.KC_HOSTNAME_STRICT contains false, which is an invalid type, it should be a string, number, or a null`