### PR TITLE
docker-compose not recognising boolean values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,13 +39,13 @@ services:
       KC_DB_DATABASE: keycloak
       KC_DB_USERNAME: keycloaker
       KC_DB_PASSWORD: keycloaked
-      KC_HTTP_ENABLED: false
-      KC_HTTPS_ENABLED: false
+      KC_HTTP_ENABLED: 'false'
+      KC_HTTPS_ENABLED: 'false'
       KC_PROXY: edge
       KC_HOSTNAME: localhost
       KC_HOSTNAME_PORT: 8080
-      KC_HOSTNAME_STRICT: false
-      KC_HOSTNAME_STRICT_HTTPS: false
+      KC_HOSTNAME_STRICT: 'false'
+      KC_HOSTNAME_STRICT_HTTPS: 'false'
       KC_LOG_LEVEL: INFO
       VAR_ADMIN_CLI_SECRET: "xxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyy"
       VAR_WEB_CLIENT_URL: "http://localhost:5500"


### PR DESCRIPTION
When running `docker-compose up -d` the following error is observed:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.keycloak.environment.KC_HTTP_ENABLED contains false, which is an invalid type, it should be a string, number, or a null
```
Remediation is by encapsulating any boolean values in single quotes so they are treated as a string as noted [here](https://github.com/docker/compose/issues/1788)

Behaviour seen in commit [57d1665d323048c9feaf34a9fabe6cc454ec4ccc](https://github.com/reconmap/reconmap/commit/57d1665d323048c9feaf34a9fabe6cc454ec4ccc)
Running `Docker version 20.10.19, build d85ef84` on ` Ubuntu 22.04.1`